### PR TITLE
support out-of-tree builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 tmp
+*build*
 *.so
 *.dll
 *.o

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Project: cobgdb
-# Makefile created by Dev-C++ 5.11
+# Makefile originally  created by Dev-C++ 5.11
 
 # detect if running under unix by finding 'rm' in $PATH :
 ifeq ($(wildcard $(addsuffix /rm,$(subst :, ,$(PATH)))),)
@@ -8,21 +8,21 @@ else
 WINMODE=0
 endif
 
+# path where the source resides - same as current Makefile's directory
+SRCDIR := $(dir $(lastword $(MAKEFILE_LIST)))
+
 #
 # Windows
 # objdump -x cobgdb.exe | findstr /R /C:"DLL"
 #
 ifeq ($(WINMODE),1)
-CPP      = g++.exe
 CC       = gcc.exe
 RES      = 
 OBJ      = cobgdb.o terminal.o read_file.o gdb_process.o parser_mi2.o parser.o mi2.o testMI2.o testParser.o realpath.o variables.o debugger.o output.o highlight.o string_parser.o
 LINKOBJ  = cobgdb.o terminal.o read_file.o gdb_process.o parser_mi2.o parser.o mi2.o testMI2.o testParser.o realpath.o variables.o debugger.o output.o highlight.o string_parser.o
 LIBS     = 
 INCS     = 
-CXXINCS  = 
 BIN      = cobgdb.exe
-CXXFLAGS = $(CXXINCS) -Wfatal-errors
 CFLAGS   = $(INCS) -fdiagnostics-color=always -g
 RM       = del
 CP       = copy
@@ -30,16 +30,13 @@ else
 #
 # Linux
 # 
-CPP      = g++
 CC       = gcc
 RES      = 
 OBJ      = cobgdb.o terminal.o read_file.o parser.o parser_mi2.o gdb_process.o mi2.o testMI2.o testParser.o variables.o debugger.o output.o highlight.o string_parser.o
 LINKOBJ  = cobgdb.o terminal.o read_file.o parser.o parser_mi2.o gdb_process.o mi2.o testMI2.o testParser.o variables.o debugger.o output.o highlight.o string_parser.o
 LIBS     = 
 INCS     = 
-CXXINCS  = 
 BIN      = cobgdb
-CXXFLAGS = $(CXXINCS) -Wfatal-errors
 CFLAGS   = $(INCS) -fdiagnostics-color=always -g
 RM       = rm -f
 CP		 = cp
@@ -61,47 +58,47 @@ clean: clean-custom
 $(BIN): $(OBJ)
 	$(CC) $(LINKOBJ) -o $(BIN) $(LIBS)
 
-cobgdb.o: cobgdb.c
-	$(CC) -c cobgdb.c -o cobgdb.o $(CFLAGS)
+cobgdb.o: $(SRCDIR)/cobgdb.c
+	$(CC) -c $(SRCDIR)/cobgdb.c -o cobgdb.o $(CFLAGS)
 
-terminal.o: terminal.c
-	$(CC) -c terminal.c -o terminal.o $(CFLAGS)
+terminal.o: $(SRCDIR)/terminal.c
+	$(CC) -c $(SRCDIR)/terminal.c -o terminal.o $(CFLAGS)
 
-read_file.o: read_file.c
-	$(CC) -c read_file.c -o read_file.o $(CFLAGS)
+read_file.o: $(SRCDIR)/read_file.c
+	$(CC) -c $(SRCDIR)/read_file.c -o read_file.o $(CFLAGS)
 
-parser.o: parser.c
-	$(CC) -c parser.c -o parser.o $(CFLAGS)
+parser.o: $(SRCDIR)/parser.c
+	$(CC) -c $(SRCDIR)/parser.c -o parser.o $(CFLAGS)
 
-gdb_process.o: gdb_process.c
-	$(CC) -c gdb_process.c -o gdb_process.o $(CFLAGS)
+gdb_process.o: $(SRCDIR)/gdb_process.c
+	$(CC) -c $(SRCDIR)/gdb_process.c -o gdb_process.o $(CFLAGS)
 
-mi2.o: mi2.c
-	$(CC) -c mi2.c -o mi2.o $(CFLAGS)
+mi2.o: $(SRCDIR)/mi2.c
+	$(CC) -c $(SRCDIR)/mi2.c -o mi2.o $(CFLAGS)
 
-parser_mi2.o: parser_mi2.c
-	$(CC) -c parser_mi2.c -o parser_mi2.o $(CFLAGS)
+parser_mi2.o: $(SRCDIR)/parser_mi2.c
+	$(CC) -c $(SRCDIR)/parser_mi2.c -o parser_mi2.o $(CFLAGS)
 
-testMI2.o: testMI2.c
-	$(CC) -c testMI2.c -o testMI2.o $(CFLAGS)
+testMI2.o: $(SRCDIR)/testMI2.c
+	$(CC) -c $(SRCDIR)/testMI2.c -o testMI2.o $(CFLAGS)
 
-testParser.o: testParser.c
-	$(CC) -c testParser.c -o testParser.o $(CFLAGS)
+testParser.o: $(SRCDIR)/testParser.c
+	$(CC) -c $(SRCDIR)/testParser.c -o testParser.o $(CFLAGS)
 
-realpath.o: realpath.c
-	$(CC) -c realpath.c -o realpath.o $(CFLAGS)
+realpath.o: $(SRCDIR)/realpath.c
+	$(CC) -c $(SRCDIR)/realpath.c -o realpath.o $(CFLAGS)
 
-variables.o: variables.c
-	$(CC) -c variables.c -o variables.o $(CFLAGS)
+variables.o: $(SRCDIR)/variables.c
+	$(CC) -c $(SRCDIR)/variables.c -o variables.o $(CFLAGS)
 
-debugger.o: debugger.c
-	$(CC) -c debugger.c -o debugger.o $(CFLAGS)
+debugger.o: $(SRCDIR)/debugger.c
+	$(CC) -c $(SRCDIR)/debugger.c -o debugger.o $(CFLAGS)
 
-output.o: output.c
-	$(CC) -c output.c -o output.o $(CFLAGS)
+output.o: $(SRCDIR)/output.c
+	$(CC) -c $(SRCDIR)/output.c -o output.o $(CFLAGS)
 
-highlight.o: highlight.c
-	$(CC) -c highlight.c -o highlight.o $(CFLAGS)
+highlight.o: $(SRCDIR)/highlight.c
+	$(CC) -c $(SRCDIR)/highlight.c -o highlight.o $(CFLAGS)
 
-string_parser.o: string_parser.c
-	$(CC) -c string_parser.c -o string_parser.o $(CFLAGS)
+string_parser.o: $(SRCDIR)/string_parser.c
+	$(CC) -c $(SRCDIR)/string_parser.c -o string_parser.o $(CFLAGS)


### PR DESCRIPTION
* adjusted Makefile
   * define and use SRCDIR variable
   * drop unused CPP and CXX
* added build directory to be ignored

This allows to use a complete different directory for building, which is quite useful when using different compilers/options.
To do so:

```sh
mkdir build_gcc
make -C build_gcc -f ../Makefile CC=gcc
mkdir build_clang
make -C build_clang -f ../Makefile CC=clang
```