### PR TITLE
mi2.c: only use strtok_r when available

### DIFF
--- a/mi2.c
+++ b/mi2.c
@@ -10,6 +10,9 @@
 #if defined(__linux__)
 #include <unistd.h>
 #endif
+#if !defined (_BSD_SOURCE) && !defined (_XOPEN_SOURCE) && !defined (_POSIX_SOURCE)
+#define strtok_r(str,tok,ptr) strtok(str,tok)
+#endif
 #include "cobgdb.h"
 //#define DEBUG 0
 


### PR DESCRIPTION
**WARNING** this may totally break mi2.c at runtime!

I've only checked that it does compile and link with GCC on both old MinGW and on Debian, using strtok_r in the second case and strtok in the first.

Please double-check if `strtok_r()` is needed (= if the code parts are expected to be used in multiple threads), in which case we may include that function with a header defining it (and the header being either in the public domain or GPLv3+).