### PR TITLE
handle invalid COBOL files (cobc errors)

### DIFF
--- a/cobgdb.c
+++ b/cobgdb.c
@@ -166,8 +166,8 @@ int cobc_compile(char file[][512], char values[10][256], int arg_count){
         printf("%s", buf);
     }
 
-    pclose(pfd);
-    return 0;
+    int ret = pclose(pfd);
+    return ret;
 }
 
 Lines * set_window_pos(int * line_pos){
@@ -800,7 +800,13 @@ int main(int argc, char **argv) {
         }
 		strcpy(fileCobGroup[nfile], "");
 		strcpy(fileCGroup[nfile], "");
-        cobc_compile(fileCobGroup, values, arg_count);
+        int ret = cobc_compile(fileCobGroup, values, arg_count);
+        if (ret) {
+            // TODO: use wait.h macros to output signal/status/...
+            printf("COBGDB: Issue in cobc, code %d\n", ret);
+            fflush(stdout);
+            return 1;
+        }
         printf("Parser starting...\n");
 		SourceMap(fileCGroup);
         printf("Parser end...\n");


### PR DESCRIPTION
I _guess_ that wait.h is quite portable, but this is up to a check (likely most easy just have a look in cobc.c how `WEXITSTATUS` and co are used); but that can be a follow-up change, this one at least fixes the issue that you may debug "invalid" source without knowing it (cobgdb parsed the _last_ valid state and started the debugging before).